### PR TITLE
Updated link to AzureGuy's blog

### DIFF
--- a/content/blogs/azure_blogs.en.md
+++ b/content/blogs/azure_blogs.en.md
@@ -62,8 +62,8 @@ chapter: true
 ![The Azure Guy](/images/blogs/theazureguy.png?width=50pc)
 
 ---
-#### [The Azure Guy](https://theazureguy.blog/) - Martyn Coupland
-![The Azure Guy](/images/blogs/theazureguy.PNG?width=50pc)
+#### {{< open-in-blank "The Azure Guy - Martyn Coupland" "https://theazureguy.blog/" >}}
+![The Azure Guy](/images/blogs/theazureguy.png?width=50pc)
 
 ---
 #### {{< open-in-blank "Kirk Ryan - A blog about advanced Azure data services" "https://kirkryan.co.uk/" >}}


### PR DESCRIPTION
There are two links to AzureGuy's blogs, the first one looks ok, the other one was missing the pattern.
Also, the second link referred to non-existing image, so changed it to the other one.
Both URLs end on the same website, so maybe one link is enough (to avoid duplicates)?