### PR TITLE
Update azure_blogs.en.md

### DIFF
--- a/content/blogs/azure_blogs.en.md
+++ b/content/blogs/azure_blogs.en.md
@@ -18,7 +18,7 @@ chapter: true
 ![Thomas Thornton](/images/blogs/thomasthornton.PNG?width=50pc)
 
 ---
-#### {{< open-in-blank "Sven Malvik - Azure Blog" "https://svenmalvik.con" >}}
+#### {{< open-in-blank "Sven Malvik - Azure Blog" "https://svenmalvik.com" >}}
 ![Thomas Thornton](/images/blogs/svenmalvik.PNG?width=50pc)
 
 ---
@@ -62,7 +62,7 @@ chapter: true
 ![Pete Gallagher](/images/blogs/petegallagher.PNG?width=50pc)
 
 ---
-#### {{< open-in-blank "The Azure Guy - Martyn Coupland" "https://theazureguy.blog/" >}}
+#### {{< open-in-blank "The Azure Guy - Martyn Coupland" "https://blog.m12d.com/" >}}
 ![The Azure Guy](/images/blogs/theazureguy.png?width=50pc)
 
 ---
@@ -197,7 +197,7 @@ chapter: true
 
 ---
 
-#### {{< open-in-blank "Roberth Strand" "https://robstr.dev" >}}
+#### {{< open-in-blank "Roberth Strand" "https://www.robstr.dev" >}}
 ![Roberth Strand](/images/blogs/robstr.png?width=50pc)
 
 ---


### PR DESCRIPTION
Fixing dead links

* Sven Malvik - Azure Blog" "https://svenmalvik.con - Looks like a simple typo n -> m
* The Azure Guy - Martyn Coupland" "https://theazureguy.blog/ - redirects to https://m12d.com/ which gives 404, but found that this is working https://blog.m12d.com/
* Roberth Strand" "https://robstr.dev" - does not work without "www"